### PR TITLE
Rework process limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Breaking these three sections into two JSON files is recommended.  One files con
     }
   },
   "scanner": {
-    "logLevel": 4,
+    "logLevel": "info",
     "partitionStack" : [
       "year",
       "month",
@@ -52,9 +52,8 @@ Breaking these three sections into two JSON files is recommended.  One files con
       "part-05"
     ],
     "limits" : {
-      "scanPrefixForPartitionsProcessLimit":   100,
-      "s3ObjectBodyProcessInProgressLimit":   300,
-      "minPercentRamFree":    25.0,
+      "scanPrefixForPartitionsProcessLimit": 10
+      "s3ObjectBodyProcessInProgressLimit": 500
       "maxFileSizeBytes": 134217728
     },
     "bounds": {

--- a/README.md
+++ b/README.md
@@ -52,11 +52,8 @@ Breaking these three sections into two JSON files is recommended.  One files con
       "part-05"
     ],
     "limits" : {
-      "maxBuildPrefixList":   100,
-      "prefixListObjectsLimit": 100,
-      "objectFetchBatchSize":        200,
-      "objectBodyFetchLimit":   300,
-      "objectBodyPutLimit":         250,
+      "scanPrefixForPartitionsProcessLimit":   100,
+      "s3ObjectBodyProcessInProgressLimit":   300,
       "minPercentRamFree":    25.0,
       "maxFileSizeBytes": 134217728
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "s3-file-scan-cat",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "s3-file-scan-cat",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.569.0",
         "@types/node": "^14.11.2",
         "@types/node-os-utils": "^1.2.0",
-        "async-wait-until": "^1.2.6",
+        "async-wait-until": "^2.0.1",
         "moment": "^2.29.1",
         "node-os-utils": "^1.3.2",
         "npm-check-updates": "^16.14.20",
@@ -974,9 +974,9 @@
       }
     },
     "node_modules/@npmcli/fs": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.0.tgz",
-      "integrity": "sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
+      "integrity": "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -2056,12 +2056,12 @@
       }
     },
     "node_modules/async-wait-until": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/async-wait-until/-/async-wait-until-1.2.6.tgz",
-      "integrity": "sha512-7I1zd0bnMEo7WfLfDoLZp+iPYKv/dl7kcW8wphazZn+BAElTGvtkDuQuonr480JzkS7f42VcGyP90mk3+3IfWA==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/async-wait-until/-/async-wait-until-2.0.12.tgz",
+      "integrity": "sha512-SXy/vDs6UPJMG6YeEYOQ4ilA/JnGxk187KPGqFx9O+qVxsjkSl+jH+3P50qSNyMpEmDgr8qOFGOKCJckWb1i7A==",
       "engines": {
-        "node": ">= 4",
-        "npm": ">= 2"
+        "node": ">= 0.12.0",
+        "npm": ">= 1.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -4625,12 +4625,9 @@
       "optional": true
     },
     "node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.1.tgz",
+      "integrity": "sha512-f/vbBsu+fOiYt+lmwZV0rVwJScl46HppnOA1ZvIuBWKOTlllpyJ3bfVax76/OrhCH38dyxoDIA8K7uB963IYgA==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4656,17 +4653,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/semver-utils/-/semver-utils-1.1.4.tgz",
       "integrity": "sha512-EjnoLE5OGmDAVV/8YDoN5KiajNadjzIp9BAHOhYeQHt7j0UWxjmgsx4YD48wp4Ue1Qogq38F1GNUJNqF1kKKxA=="
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3-file-scan-cat",
-  "version": "0.10.1",
+  "version": "1.0.0",
   "description": "A utility to recursively scan a specified folder in S3 and concat JSON files within a single folder into a single gzip file.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@aws-sdk/client-s3": "^3.569.0",
     "@types/node": "^14.11.2",
     "@types/node-os-utils": "^1.2.0",
-    "async-wait-until": "^1.2.6",
+    "async-wait-until": "^2.0.1",
     "moment": "^2.29.1",
     "node-os-utils": "^1.3.2",
     "npm-check-updates": "^16.14.20",

--- a/src/S3FileScanCat.ts
+++ b/src/S3FileScanCat.ts
@@ -269,7 +269,7 @@ export class S3FileScanCat {
                 console.log(`[ERROR] S3 getObjectFailed: ${error}`)
                 lastError = error
                 if (retryCount < MAX_RETRIES) {
-                    this.log(LogLevel.Debug, `STATUS RETRY! _getObjectBody s3Key=${s3Key} - this._s3ObjectBodyProcessCount: ${this._s3ObjectBodyProcessInProgress} - retryCount: ${retryCount}`)
+                    this.log(LogLevel.Debug, `STATUS RETRY! _getAndProcessObjectBody s3Key=${s3Key} - _s3ObjectBodyProcessCount: ${this._s3ObjectBodyProcessInProgress} - retryCount: ${retryCount}`)
                     await this._sleep(this._getWaitTimeForRetry(retryCount++))
                 } else {
                     break

--- a/src/S3FileScanCat.ts
+++ b/src/S3FileScanCat.ts
@@ -133,7 +133,7 @@ export class S3FileScanCat {
                     if(this._scanPrefixForPartitionsProcessCount < this._scannerOptions.limits.scanPrefixForPartitionsProcessLimit) {
                         return true
                     } else if(waits++ % 20 === 0) {
-                        this.log(LogLevel.Trace, `Waiting on ListObjects to complete prefix=${srcPrefix} `)
+                        this.log(LogLevel.Debug, `Waiting on ListObjects to complete prefix=${srcPrefix} `)
                     }
                 },
                 { timeout: WAIT_FOREVER }
@@ -183,7 +183,7 @@ export class S3FileScanCat {
             this._s3PrefixListObjectsProcessCount++
             let response: ListObjectsV2CommandOutput
             try {
-                this.log(LogLevel.Debug, `STATUS _concatFilesAtPrefix prefix=${prefix} - this._s3PrefixListObjectsProcessCount: ${this._s3PrefixListObjectsProcessCount}`)
+                this.log(LogLevel.Trace, `STATUS _concatFilesAtPrefix prefix=${prefix} - this._s3PrefixListObjectsProcessCount: ${this._s3PrefixListObjectsProcessCount}`)
                 response = await this._s3Client.send(new ListObjectsV2Command(listObjRequest))
             } catch (e) {
                 this.log(LogLevel.Error, `Failed to list objects for ${listObjRequest.Prefix}, Error: ${e}`)
@@ -221,7 +221,7 @@ export class S3FileScanCat {
                 throw new Error(`Unexpected Error: List S3 Objects request had missing response.`)
             }
             this._s3PrefixListObjectsProcessCount--
-            this.log(LogLevel.Debug, `STATUS _concatFilesAtPrefix prefix=${prefix} - _s3PrefixListObjectsProcessCount: ${this._s3PrefixListObjectsProcessCount}`)
+            this.log(LogLevel.Trace, `STATUS _concatFilesAtPrefix prefix=${prefix} - _s3PrefixListObjectsProcessCount: ${this._s3PrefixListObjectsProcessCount}`)
         } while (concatState.continuationToken)
         // Finally wait until all the objects have been fetched and processed
         await waitUntil(
@@ -269,7 +269,7 @@ export class S3FileScanCat {
                 console.log(`[ERROR] S3 getObjectFailed: ${error}`)
                 lastError = error
                 if (retryCount < MAX_RETRIES) {
-                    this.log(LogLevel.Debug, `STATUS RETRY! _getAndProcessObjectBody s3Key=${s3Key} - _s3ObjectBodyProcessCount: ${this._s3ObjectBodyProcessInProgress} - retryCount: ${retryCount}`)
+                    this.log(LogLevel.Warn, `STATUS RETRY! _getAndProcessObjectBody s3Key=${s3Key} - _s3ObjectBodyProcessCount: ${this._s3ObjectBodyProcessInProgress} - retryCount: ${retryCount}`)
                     await this._sleep(this._getWaitTimeForRetry(retryCount++))
                 } else {
                     break

--- a/src/interfaces/scanner.interface.ts
+++ b/src/interfaces/scanner.interface.ts
@@ -23,11 +23,8 @@ export interface LoggerOptions {
 }
 
 export interface ScannerLimits {
-    maxBuildPrefixList: number
-    prefixListObjectsLimit: number
-    objectFetchBatchSize: number
-    objectBodyFetchLimit: number
-    objectBodyPutLimit: number
+    scanPrefixForPartitionsProcessLimit: number
+    s3ObjectBodyProcessInProgressLimit: number
     maxFileSizeBytes: number
 }
 


### PR DESCRIPTION
In a lot of wayts things are simplified significantly to make tuning more intuitive.

Removed the following:
    maxBuildPrefixList
    prefixListObjectsLimit
    objectFetchBatchSize
    objectBodyFetchLimit
    objectBodyPutLimit

Added the following:
    `scanPrefixForPartitionsProcessLimit`: The max number of processes allowed to be scanning for partitions when `scanAndProcessFiles` is kicked off. This scan is essentially a series of calls to the`ListObjectsV2Command` walking down a prefix path determining partitions that exist within it.
    `s3ObjectBodyProcessInProgressLimit`: This is the maximum number of S3 Objects that are being fetched and processed at any given moment. In theory, this is the number of calls to`GetObjectCommand` that are constantly active until the end of the process.