### PR TITLE
Add concurrency limits for S3FileScanCat processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ Phase 1 (partition discovery) fans out up to `scanPrefixForPartitionsProcessLimi
 Phase 2 (concatenate-and-write) supports three optional knobs that default to the original strictly-sequential behavior, so upgrades are safe without any config changes:
 
 - **`concatFilesAtPrefixProcessLimit`** — max leaf prefixes being concatenated at once. Default `1` (sequential). Raising this is the primary speedup lever when you have many small leaves.
-- **`s3ObjectBodyProcessTotalLimit`** — class-wide cap on in-flight `GetObject` bodies across all concurrent leaves. Default `Infinity`. Must be >= `s3ObjectBodyProcessInProgressLimit`. Use this together with `concatFilesAtPrefixProcessLimit > 1` to bound socket usage on the shared S3 HTTP(S) agents (which cap at 500 sockets).
+- **`s3ObjectBodyProcessTotalLimit`** — class-wide cap on in-flight `GetObject` bodies across all concurrent leaves. Default `Infinity`. Must be >= `s3ObjectBodyProcessInProgressLimit`. Use this together with `concatFilesAtPrefixProcessLimit > 1` to bound concurrent `GetObject` work on the shared S3 HTTP(S) agents (default `maxSockets` is **500 total** across list, get, and put).
 - **`s3ObjectPutProcessLimit`** — cap on concurrent `PutObject` calls across the whole scanner. Default `Infinity`. Pair with `concatFilesAtPrefixProcessLimit > 1` to avoid flush-time bursts against the destination prefix.
 
-Memory/socket ceilings to watch: peak concat-buffer memory is roughly `concatFilesAtPrefixProcessLimit × maxFileSizeBytes`, and peak source-body memory is bounded by `s3ObjectBodyProcessTotalLimit × maxSourceObjectSizeBytes`. Keep `s3ObjectBodyProcessTotalLimit + s3ObjectPutProcessLimit` comfortably below the `500` `maxSockets` budget so lists, gets, and puts don't starve one another.
+Memory/socket ceilings to watch: peak concat-buffer memory is roughly `concatFilesAtPrefixProcessLimit × maxFileSizeBytes`, and peak source-body memory is bounded by `s3ObjectBodyProcessTotalLimit × maxSourceObjectSizeBytes`. Sockets are shared: phase 1 runs up to `scanPrefixForPartitionsProcessLimit` concurrent `ListObjectsV2` calls, phase 2 can run about one listing stream per in-flight leaf (`concatFilesAtPrefixProcessLimit`), and `GetObject` / `PutObject` concurrency is capped by `s3ObjectBodyProcessTotalLimit` / `s3ObjectPutProcessLimit`. Keep that **aggregate** demand comfortably below the `500` `maxSockets` budget so lists, gets, and puts don't starve one another.
 
 ### Performing the scan
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Keeping credentials in a separate file from the rest of the config is recommende
     "limits": {
       "scanPrefixForPartitionsProcessLimit": 10,
       "s3ObjectBodyProcessInProgressLimit": 500,
+      "concatFilesAtPrefixProcessLimit": 4,
+      "s3ObjectBodyProcessTotalLimit": 500,
+      "s3ObjectPutProcessLimit": 64,
       "maxFileSizeBytes": 134217728
     },
     "bounds": {
@@ -74,6 +77,18 @@ Keeping credentials in a separate file from the rest of the config is recommende
 ```
 
 Omit `loggerOptions` entirely to disable library logging. When `bounds.startDate` and `bounds.endDate` are set, use **`YYYY-MM-DD`** strings; they are interpreted as **UTC** calendar days.
+
+### Tuning concurrency
+
+Phase 1 (partition discovery) fans out up to `scanPrefixForPartitionsProcessLimit` `ListObjectsV2` workers.
+
+Phase 2 (concatenate-and-write) supports three optional knobs that default to the original strictly-sequential behavior, so upgrades are safe without any config changes:
+
+- **`concatFilesAtPrefixProcessLimit`** — max leaf prefixes being concatenated at once. Default `1` (sequential). Raising this is the primary speedup lever when you have many small leaves.
+- **`s3ObjectBodyProcessTotalLimit`** — class-wide cap on in-flight `GetObject` bodies across all concurrent leaves. Default `Infinity`. Must be >= `s3ObjectBodyProcessInProgressLimit`. Use this together with `concatFilesAtPrefixProcessLimit > 1` to bound socket usage on the shared S3 HTTP(S) agents (which cap at 500 sockets).
+- **`s3ObjectPutProcessLimit`** — cap on concurrent `PutObject` calls across the whole scanner. Default `Infinity`. Pair with `concatFilesAtPrefixProcessLimit > 1` to avoid flush-time bursts against the destination prefix.
+
+Memory/socket ceilings to watch: peak concat-buffer memory is roughly `concatFilesAtPrefixProcessLimit × maxFileSizeBytes`, and peak source-body memory is bounded by `s3ObjectBodyProcessTotalLimit × maxSourceObjectSizeBytes`. Keep `s3ObjectBodyProcessTotalLimit + s3ObjectPutProcessLimit` comfortably below the `500` `maxSockets` budget so lists, gets, and puts don't starve one another.
 
 ### Performing the scan
 

--- a/src/S3FileScanCat.ts
+++ b/src/S3FileScanCat.ts
@@ -1339,44 +1339,48 @@ export class S3FileScanCat {
     async _saveToS3(bucket: string, buffer: string, key: string): Promise<void> {
         void this._logger?.trace(`BEGIN _saveToS3 key=${key} - _s3ObjectPutProcessCount: ${this._s3ObjectPutProcessCount}`)
 
-        // Class-level PutObject cap. The `tryAcquire` predicate performs the check-and-bump
-        // atomically (synchronously) so racing flush promises cannot both observe the gate as
-        // open. With the default `Infinity` the predicate always acquires on the first call and
-        // this is a no-op. When fatal, we short-circuit without bumping.
-        let putSlotAcquired = false
-        if (Number.isFinite(this._s3ObjectPutProcessLimit)) {
-            let putWaits = 0
-            await waitUntil(
-                () => {
-                    if (this._fatalScanError) {
-                        return true
-                    }
-                    if (this._s3ObjectPutProcessCount < this._s3ObjectPutProcessLimit) {
-                        this._s3ObjectPutProcessCount++
-                        putSlotAcquired = true
-                        return true
-                    }
-                    if (putWaits++ % 20 === 0) {
-                        void this._logger?.trace(
-                            `Waiting until PutObject workers drop below limit (inFlight=${this._s3ObjectPutProcessCount}, limit=${this._s3ObjectPutProcessLimit})`
-                        )
-                    }
-                    return false
-                },
-                { timeout: this._waitUntilTimeoutMs }
+        // Fast fatal-error abort so a PUT never lands for a run that has already failed. This
+        // must run before the counter bump in either the finite or infinite branch below,
+        // otherwise the infinite branch would happily gzip + PUT after a sibling has rejected.
+        if (this._fatalScanError) {
+            void this._logger?.trace(
+                `Abandoning _saveToS3 key=${key} due to prior fatal scan error.`
             )
-            if (this._fatalScanError && !putSlotAcquired) {
-                // Honor the same abort semantics as other workers: skip the PUT and let the
-                // outer flush tracker's allSettled drain it. No counters to revert.
-                void this._logger?.trace(
-                    `Abandoning _saveToS3 key=${key} due to prior fatal scan error.`
-                )
-                return
-            }
-        } else {
-            // Unbounded: bump eagerly so both branches share the release path below.
-            this._s3ObjectPutProcessCount++
-            putSlotAcquired = true
+            return
+        }
+
+        // Acquire a PutObject slot (class-level cap). The atomic check-and-bump inside the
+        // predicate means two racing flush promises cannot both observe the gate as open. With
+        // the default `Infinity` limit the predicate succeeds on the very first call, so this
+        // reduces to a single microtask yield. A fatal error observed mid-wait short-circuits
+        // without bumping, and we abandon the PUT below.
+        let putSlotAcquired = false
+        let putWaits = 0
+        await waitUntil(
+            () => {
+                if (this._fatalScanError) {
+                    return true
+                }
+                if (this._s3ObjectPutProcessCount < this._s3ObjectPutProcessLimit) {
+                    this._s3ObjectPutProcessCount++
+                    putSlotAcquired = true
+                    return true
+                }
+                if (putWaits++ % 20 === 0) {
+                    void this._logger?.trace(
+                        `Waiting until PutObject workers drop below limit (inFlight=${this._s3ObjectPutProcessCount}, limit=${this._s3ObjectPutProcessLimit})`
+                    )
+                }
+                return false
+            },
+            { timeout: this._waitUntilTimeoutMs }
+        )
+        if (!putSlotAcquired) {
+            // Fatal became set while we were waiting for a slot; nothing to release.
+            void this._logger?.trace(
+                `Abandoning _saveToS3 key=${key} due to fatal scan error during slot wait.`
+            )
+            return
         }
 
         try {

--- a/src/S3FileScanCat.ts
+++ b/src/S3FileScanCat.ts
@@ -127,57 +127,39 @@ export class S3FileScanCat {
             scannerOptions.limits?.s3ObjectBodyProcessInProgressLimit !== undefined
                 ? scannerOptions.limits?.s3ObjectBodyProcessInProgressLimit
                 : 100
-        // New concurrency limits (phase-2 parallelism). Validation happens here so that bad
-        // config fails fast at construction instead of deep inside the scan. Fractional values
-        // are rejected because every gate compares `count < limit` and then bumps the counter
-        // by exactly 1 — a limit of 1.5 would allow 2 concurrent workers (since 1 < 1.5) and
-        // silently violate the cap.
-        this._concatFilesAtPrefixProcessLimit =
-            scannerOptions.limits?.concatFilesAtPrefixProcessLimit !== undefined
-                ? scannerOptions.limits.concatFilesAtPrefixProcessLimit
-                : 1
-        if (
-            !Number.isInteger(this._concatFilesAtPrefixProcessLimit) ||
-            this._concatFilesAtPrefixProcessLimit < 1
-        ) {
-            throw new RangeError(
-                `scannerOptions.limits.concatFilesAtPrefixProcessLimit must be an integer >= 1; received ${scannerOptions.limits?.concatFilesAtPrefixProcessLimit}`
-            )
-        }
-        // Default to Infinity (opt-in) so existing callers — including any who drive
+        // New concurrency limits (phase-2 parallelism). Validation happens here so bad config
+        // fails fast at construction instead of deep inside the scan. Every gate compares
+        // `count < limit` and bumps the counter by exactly 1, so the limit MUST be an
+        // integer: a limit of 1.5 would allow 2 workers (1 < 1.5) and silently violate the cap,
+        // and a limit of NaN would make every comparison false — producing an indefinite
+        // `waitUntil` spin that only breaks at `waitUntilTimeoutMs`.
+        this._concatFilesAtPrefixProcessLimit = S3FileScanCat._validateConcurrencyLimit(
+            'concatFilesAtPrefixProcessLimit',
+            scannerOptions.limits?.concatFilesAtPrefixProcessLimit,
+            { defaultValue: 1, allowInfinity: false }
+        )
+        // Default Infinity (opt-in) so existing callers — including any who drive
         // `concatFilesAtPrefix` directly across calls — see no change. When explicitly set,
         // the value must be a positive integer (same rationale as above) and >= the per-leaf
-        // limit so a single leaf cannot deadlock on itself (the inner `waitUntil` gates on
-        // both caps).
-        this._s3ObjectBodyProcessTotalLimit =
-            scannerOptions.limits?.s3ObjectBodyProcessTotalLimit !== undefined
-                ? scannerOptions.limits.s3ObjectBodyProcessTotalLimit
-                : Number.POSITIVE_INFINITY
-        if (scannerOptions.limits?.s3ObjectBodyProcessTotalLimit !== undefined) {
-            const v = this._s3ObjectBodyProcessTotalLimit
-            if (v !== Number.POSITIVE_INFINITY && (!Number.isInteger(v) || v < 1)) {
-                throw new RangeError(
-                    `scannerOptions.limits.s3ObjectBodyProcessTotalLimit must be a positive integer or Infinity; received ${v}`
-                )
-            }
-            if (v < this._s3ObjectBodyProcessInProgressLimit) {
-                throw new RangeError(
-                    `scannerOptions.limits.s3ObjectBodyProcessTotalLimit (${v}) must be >= s3ObjectBodyProcessInProgressLimit (${this._s3ObjectBodyProcessInProgressLimit}).`
-                )
-            }
+        // limit so a single leaf cannot deadlock on itself (the inner gate checks both caps).
+        this._s3ObjectBodyProcessTotalLimit = S3FileScanCat._validateConcurrencyLimit(
+            's3ObjectBodyProcessTotalLimit',
+            scannerOptions.limits?.s3ObjectBodyProcessTotalLimit,
+            { defaultValue: Number.POSITIVE_INFINITY, allowInfinity: true }
+        )
+        if (
+            scannerOptions.limits?.s3ObjectBodyProcessTotalLimit !== undefined &&
+            this._s3ObjectBodyProcessTotalLimit < this._s3ObjectBodyProcessInProgressLimit
+        ) {
+            throw new RangeError(
+                `scannerOptions.limits.s3ObjectBodyProcessTotalLimit (${this._s3ObjectBodyProcessTotalLimit}) must be >= s3ObjectBodyProcessInProgressLimit (${this._s3ObjectBodyProcessInProgressLimit}).`
+            )
         }
-        this._s3ObjectPutProcessLimit =
-            scannerOptions.limits?.s3ObjectPutProcessLimit !== undefined
-                ? scannerOptions.limits.s3ObjectPutProcessLimit
-                : Number.POSITIVE_INFINITY
-        if (scannerOptions.limits?.s3ObjectPutProcessLimit !== undefined) {
-            const v = this._s3ObjectPutProcessLimit
-            if (v !== Number.POSITIVE_INFINITY && (!Number.isInteger(v) || v < 1)) {
-                throw new RangeError(
-                    `scannerOptions.limits.s3ObjectPutProcessLimit must be a positive integer or Infinity; received ${v}`
-                )
-            }
-        }
+        this._s3ObjectPutProcessLimit = S3FileScanCat._validateConcurrencyLimit(
+            's3ObjectPutProcessLimit',
+            scannerOptions.limits?.s3ObjectPutProcessLimit,
+            { defaultValue: Number.POSITIVE_INFINITY, allowInfinity: true }
+        )
         this._maxFileSizeBytes =
             scannerOptions.limits?.maxFileSizeBytes !== undefined
                 ? scannerOptions.limits?.maxFileSizeBytes
@@ -1031,6 +1013,51 @@ export class S3FileScanCat {
             return
         }
         this._fatalScanError = err instanceof Error ? err : new Error(String(err))
+    }
+
+    /**
+     * Validate a concurrency-limit option. Concurrency gates are implemented as `count < limit`
+     * followed by `count++`, so the limit must be an integer (fractional values would allow
+     * overshoot) and must be a real number (NaN would make every comparison false, causing
+     * `waitUntil` to spin until the configured timeout).
+     *
+     * @param name Field name (for error messages).
+     * @param raw Caller-supplied value (may be `undefined` to select the default).
+     * @param defaultValue Value to use when `raw === undefined`. Assumed to be already valid.
+     * @param allowInfinity Whether `Number.POSITIVE_INFINITY` is an accepted value. Use `true`
+     *   for "unbounded" caps that the caller opts into explicitly; `false` for counts that must
+     *   correspond to a discrete number of workers.
+     */
+    private static _validateConcurrencyLimit(
+        name: string,
+        raw: number | undefined,
+        options: { defaultValue: number; allowInfinity: boolean }
+    ): number {
+        if (raw === undefined) {
+            return options.defaultValue
+        }
+        if (typeof raw !== 'number' || Number.isNaN(raw)) {
+            throw new RangeError(
+                `scannerOptions.limits.${name} must be a number; received ${raw === null ? 'null' : typeof raw}${Number.isNaN(raw as number) ? ' (NaN)' : ''}.`
+            )
+        }
+        if (raw === Number.POSITIVE_INFINITY) {
+            if (!options.allowInfinity) {
+                throw new RangeError(
+                    `scannerOptions.limits.${name} must be a finite integer >= 1; Infinity is not allowed.`
+                )
+            }
+            return raw
+        }
+        if (!Number.isInteger(raw) || raw < 1) {
+            const allowedSuffix = options.allowInfinity
+                ? ' or Infinity'
+                : ''
+            throw new RangeError(
+                `scannerOptions.limits.${name} must be an integer >= 1${allowedSuffix}; received ${raw}.`
+            )
+        }
+        return raw
     }
 
     /**

--- a/src/S3FileScanCat.ts
+++ b/src/S3FileScanCat.ts
@@ -1023,10 +1023,11 @@ export class S3FileScanCat {
      *
      * @param name Field name (for error messages).
      * @param raw Caller-supplied value (may be `undefined` to select the default).
-     * @param defaultValue Value to use when `raw === undefined`. Assumed to be already valid.
-     * @param allowInfinity Whether `Number.POSITIVE_INFINITY` is an accepted value. Use `true`
-     *   for "unbounded" caps that the caller opts into explicitly; `false` for counts that must
-     *   correspond to a discrete number of workers.
+     * @param options Validation configuration.
+     * @param options.defaultValue Value to use when `raw === undefined`. Assumed to be already valid.
+     * @param options.allowInfinity Whether `Number.POSITIVE_INFINITY` is an accepted value. Use
+     *   `true` for "unbounded" caps that the caller opts into explicitly; `false` for counts that
+     *   must correspond to a discrete number of workers.
      */
     private static _validateConcurrencyLimit(
         name: string,
@@ -1351,9 +1352,9 @@ export class S3FileScanCat {
 
         // Acquire a PutObject slot (class-level cap). The atomic check-and-bump inside the
         // predicate means two racing flush promises cannot both observe the gate as open. With
-        // the default `Infinity` limit the predicate succeeds on the very first call, so this
-        // reduces to a single microtask yield. A fatal error observed mid-wait short-circuits
-        // without bumping, and we abandon the PUT below.
+        // the default `Infinity` limit the predicate succeeds on the first evaluation, so
+        // `waitUntil` never awaits its poll timer (`setTimeout` between checks). A fatal error
+        // observed mid-wait short-circuits without bumping, and we abandon the PUT below.
         let putSlotAcquired = false
         let putWaits = 0
         await waitUntil(

--- a/src/S3FileScanCat.ts
+++ b/src/S3FileScanCat.ts
@@ -656,12 +656,21 @@ export class S3FileScanCat {
                                 void this._logger?.warn(
                                     `Skipping GetObject: listing Size (${s3Object.Size}) exceeds maxSourceObjectSizeBytes (${this._maxSourceObjectSizeBytes}) for key=${s3Object.Key}; preserving ordering with an empty slot.`
                                 )
+                                const oversizedSlot = { reserved: false }
                                 await waitUntil(
                                     () =>
-                                        this._tryAcquireBodySlot(concatState, prefix, () => waits++),
+                                        this._tryAcquireBodySlot(
+                                            concatState,
+                                            prefix,
+                                            () => waits++,
+                                            oversizedSlot
+                                        ),
                                     { timeout: this._waitUntilTimeoutMs }
                                 )
                                 if (this._fatalScanError) {
+                                    if (oversizedSlot.reserved) {
+                                        this._releaseBodySlotReservation(concatState)
+                                    }
                                     break
                                 }
                                 // The slot was reserved synchronously inside the acquire
@@ -690,11 +699,21 @@ export class S3FileScanCat {
                                 inFlightBodies.add(skipPromise)
                                 continue
                             }
+                            const bodySlot = { reserved: false }
                             await waitUntil(
-                                () => this._tryAcquireBodySlot(concatState, prefix, () => waits++),
+                                () =>
+                                    this._tryAcquireBodySlot(
+                                        concatState,
+                                        prefix,
+                                        () => waits++,
+                                        bodySlot
+                                    ),
                                 { timeout: this._waitUntilTimeoutMs }
                             )
                             if (this._fatalScanError) {
+                                if (bodySlot.reserved) {
+                                    this._releaseBodySlotReservation(concatState)
+                                }
                                 break
                             }
                             // Assign the listing-order sequence BEFORE spawning so that even
@@ -1123,6 +1142,16 @@ export class S3FileScanCat {
     }
 
     /**
+     * Undo a successful `_tryAcquireBodySlot` bump when the caller will not spawn
+     * `_getAndProcessObjectBody` / `_skipListedObjectOversizedForConcat` (e.g. fatal scan error
+     * after `waitUntil` resolved).
+     */
+    private _releaseBodySlotReservation(concatState: ConcatState): void {
+        concatState.bodiesInFlight--
+        this._s3ObjectBodyProcessInProgress--
+    }
+
+    /**
      * Atomic check-and-increment used as the `waitUntil` predicate for body-worker slots.
      * Runs synchronously, so the gate evaluation and the counter bump are inseparable — even
      * with multiple `concatFilesAtPrefix` calls racing, no two can both observe the gate as
@@ -1130,12 +1159,15 @@ export class S3FileScanCat {
      * caller can abort (no counters are bumped on the fatal path).
      *
      * Releasing is done by `_getAndProcessObjectBody` / `_skipListedObjectOversizedForConcat`
-     * in their `finally` blocks.
+     * in their `finally` blocks. Callers that acquire inside `waitUntil` and may `break` before
+     * spawning those workers pass `acquiredOut`; on fatal after `waitUntil` resolves, they must
+     * call `_releaseBodySlotReservation` when `acquiredOut.reserved` is true.
      */
     private _tryAcquireBodySlot(
         concatState: ConcatState,
         prefix: string,
-        bumpWaits: () => number
+        bumpWaits: () => number,
+        acquiredOut?: { reserved: boolean }
     ): boolean {
         if (this._fatalScanError) {
             return true
@@ -1146,6 +1178,9 @@ export class S3FileScanCat {
         ) {
             concatState.bodiesInFlight++
             this._s3ObjectBodyProcessInProgress++
+            if (acquiredOut !== undefined) {
+                acquiredOut.reserved = true
+            }
             return true
         }
         if (bumpWaits() % 20 === 0) {

--- a/src/S3FileScanCat.ts
+++ b/src/S3FileScanCat.ts
@@ -128,43 +128,55 @@ export class S3FileScanCat {
                 ? scannerOptions.limits?.s3ObjectBodyProcessInProgressLimit
                 : 100
         // New concurrency limits (phase-2 parallelism). Validation happens here so that bad
-        // config fails fast at construction instead of deep inside the scan.
+        // config fails fast at construction instead of deep inside the scan. Fractional values
+        // are rejected because every gate compares `count < limit` and then bumps the counter
+        // by exactly 1 — a limit of 1.5 would allow 2 concurrent workers (since 1 < 1.5) and
+        // silently violate the cap.
         this._concatFilesAtPrefixProcessLimit =
             scannerOptions.limits?.concatFilesAtPrefixProcessLimit !== undefined
                 ? scannerOptions.limits.concatFilesAtPrefixProcessLimit
                 : 1
         if (
-            !Number.isFinite(this._concatFilesAtPrefixProcessLimit) ||
+            !Number.isInteger(this._concatFilesAtPrefixProcessLimit) ||
             this._concatFilesAtPrefixProcessLimit < 1
         ) {
             throw new RangeError(
-                `scannerOptions.limits.concatFilesAtPrefixProcessLimit must be a finite integer >= 1; received ${scannerOptions.limits?.concatFilesAtPrefixProcessLimit}`
+                `scannerOptions.limits.concatFilesAtPrefixProcessLimit must be an integer >= 1; received ${scannerOptions.limits?.concatFilesAtPrefixProcessLimit}`
             )
         }
         // Default to Infinity (opt-in) so existing callers — including any who drive
         // `concatFilesAtPrefix` directly across calls — see no change. When explicitly set,
-        // the value must be >= the per-leaf limit so a single leaf cannot deadlock on itself
-        // (the inner `waitUntil` gates on both caps).
+        // the value must be a positive integer (same rationale as above) and >= the per-leaf
+        // limit so a single leaf cannot deadlock on itself (the inner `waitUntil` gates on
+        // both caps).
         this._s3ObjectBodyProcessTotalLimit =
             scannerOptions.limits?.s3ObjectBodyProcessTotalLimit !== undefined
                 ? scannerOptions.limits.s3ObjectBodyProcessTotalLimit
                 : Number.POSITIVE_INFINITY
-        if (
-            scannerOptions.limits?.s3ObjectBodyProcessTotalLimit !== undefined &&
-            this._s3ObjectBodyProcessTotalLimit < this._s3ObjectBodyProcessInProgressLimit
-        ) {
-            throw new RangeError(
-                `scannerOptions.limits.s3ObjectBodyProcessTotalLimit (${this._s3ObjectBodyProcessTotalLimit}) must be >= s3ObjectBodyProcessInProgressLimit (${this._s3ObjectBodyProcessInProgressLimit}).`
-            )
+        if (scannerOptions.limits?.s3ObjectBodyProcessTotalLimit !== undefined) {
+            const v = this._s3ObjectBodyProcessTotalLimit
+            if (v !== Number.POSITIVE_INFINITY && (!Number.isInteger(v) || v < 1)) {
+                throw new RangeError(
+                    `scannerOptions.limits.s3ObjectBodyProcessTotalLimit must be a positive integer or Infinity; received ${v}`
+                )
+            }
+            if (v < this._s3ObjectBodyProcessInProgressLimit) {
+                throw new RangeError(
+                    `scannerOptions.limits.s3ObjectBodyProcessTotalLimit (${v}) must be >= s3ObjectBodyProcessInProgressLimit (${this._s3ObjectBodyProcessInProgressLimit}).`
+                )
+            }
         }
         this._s3ObjectPutProcessLimit =
             scannerOptions.limits?.s3ObjectPutProcessLimit !== undefined
                 ? scannerOptions.limits.s3ObjectPutProcessLimit
                 : Number.POSITIVE_INFINITY
-        if (this._s3ObjectPutProcessLimit < 1) {
-            throw new RangeError(
-                `scannerOptions.limits.s3ObjectPutProcessLimit must be >= 1; received ${scannerOptions.limits?.s3ObjectPutProcessLimit}`
-            )
+        if (scannerOptions.limits?.s3ObjectPutProcessLimit !== undefined) {
+            const v = this._s3ObjectPutProcessLimit
+            if (v !== Number.POSITIVE_INFINITY && (!Number.isInteger(v) || v < 1)) {
+                throw new RangeError(
+                    `scannerOptions.limits.s3ObjectPutProcessLimit must be a positive integer or Infinity; received ${v}`
+                )
+            }
         }
         this._maxFileSizeBytes =
             scannerOptions.limits?.maxFileSizeBytes !== undefined

--- a/src/S3FileScanCat.ts
+++ b/src/S3FileScanCat.ts
@@ -74,6 +74,19 @@ export class S3FileScanCat {
     /** Once true, every future `scanAndProcessFiles` call rejects instead of issuing S3 traffic. */
     private _isClosed: boolean = false
     private _s3ObjectBodyProcessInProgressLimit: number
+    /** Class-level cap on aggregate `_getAndProcessObjectBody` workers; see ScannerLimits. */
+    private _s3ObjectBodyProcessTotalLimit: number
+    /** Class-level cap on concurrent `PutObject` calls; `Infinity` by default. */
+    private _s3ObjectPutProcessLimit: number
+    /** Max concurrent `concatFilesAtPrefix` calls in phase 2 (default 1 = sequential). */
+    private _concatFilesAtPrefixProcessLimit: number
+    /** Number of `concatFilesAtPrefix` calls currently in flight; see phase-2 worker spawn. */
+    private _concatFilesAtPrefixProcessCount: number = 0
+    /**
+     * Tracks every in-flight `concatFilesAtPrefix` promise so phase-2 can drain them on fatal
+     * error or normal completion before returning (mirrors `_inFlightPartitionScans`).
+     */
+    private _inFlightConcatCalls: Set<Promise<void>> = new Set()
     private _maxFileSizeBytes: number
     /** Upper bound on listing `Size` before we will issue GetObject (defaults to maxFileSizeBytes). */
     private _maxSourceObjectSizeBytes: number
@@ -114,6 +127,45 @@ export class S3FileScanCat {
             scannerOptions.limits?.s3ObjectBodyProcessInProgressLimit !== undefined
                 ? scannerOptions.limits?.s3ObjectBodyProcessInProgressLimit
                 : 100
+        // New concurrency limits (phase-2 parallelism). Validation happens here so that bad
+        // config fails fast at construction instead of deep inside the scan.
+        this._concatFilesAtPrefixProcessLimit =
+            scannerOptions.limits?.concatFilesAtPrefixProcessLimit !== undefined
+                ? scannerOptions.limits.concatFilesAtPrefixProcessLimit
+                : 1
+        if (
+            !Number.isFinite(this._concatFilesAtPrefixProcessLimit) ||
+            this._concatFilesAtPrefixProcessLimit < 1
+        ) {
+            throw new RangeError(
+                `scannerOptions.limits.concatFilesAtPrefixProcessLimit must be a finite integer >= 1; received ${scannerOptions.limits?.concatFilesAtPrefixProcessLimit}`
+            )
+        }
+        // Default to Infinity (opt-in) so existing callers — including any who drive
+        // `concatFilesAtPrefix` directly across calls — see no change. When explicitly set,
+        // the value must be >= the per-leaf limit so a single leaf cannot deadlock on itself
+        // (the inner `waitUntil` gates on both caps).
+        this._s3ObjectBodyProcessTotalLimit =
+            scannerOptions.limits?.s3ObjectBodyProcessTotalLimit !== undefined
+                ? scannerOptions.limits.s3ObjectBodyProcessTotalLimit
+                : Number.POSITIVE_INFINITY
+        if (
+            scannerOptions.limits?.s3ObjectBodyProcessTotalLimit !== undefined &&
+            this._s3ObjectBodyProcessTotalLimit < this._s3ObjectBodyProcessInProgressLimit
+        ) {
+            throw new RangeError(
+                `scannerOptions.limits.s3ObjectBodyProcessTotalLimit (${this._s3ObjectBodyProcessTotalLimit}) must be >= s3ObjectBodyProcessInProgressLimit (${this._s3ObjectBodyProcessInProgressLimit}).`
+            )
+        }
+        this._s3ObjectPutProcessLimit =
+            scannerOptions.limits?.s3ObjectPutProcessLimit !== undefined
+                ? scannerOptions.limits.s3ObjectPutProcessLimit
+                : Number.POSITIVE_INFINITY
+        if (this._s3ObjectPutProcessLimit < 1) {
+            throw new RangeError(
+                `scannerOptions.limits.s3ObjectPutProcessLimit must be >= 1; received ${scannerOptions.limits?.s3ObjectPutProcessLimit}`
+            )
+        }
         this._maxFileSizeBytes =
             scannerOptions.limits?.maxFileSizeBytes !== undefined
                 ? scannerOptions.limits?.maxFileSizeBytes
@@ -228,20 +280,28 @@ export class S3FileScanCat {
     }
 
     /**
-     * @deprecated The underlying value toggles 0/1 per concat-phase page rather than counting
-     * concurrent list-objects requests. Prefer `concatListObjectsInProgress` or
-     * `getStats().concatListObjectsInProgress`. This getter will be removed in a future major version.
+     * @deprecated Misnamed. The value is the aggregate number of list-objects requests currently
+     * in flight across all active `concatFilesAtPrefix` calls — 0 or 1 when
+     * `concatFilesAtPrefixProcessLimit === 1`, and up to that limit when multiple leaves run in
+     * parallel. Prefer `concatListObjectsInProgress` or `getStats().concatListObjectsInProgress`.
+     * This getter will be removed in a future major version.
      */
     get s3PrefixListObjectsProcessCount(): number {
         return this._s3PrefixListObjectsProcessCount
     }
 
     /**
-     * Whether a list-objects request is currently in flight inside `concatFilesAtPrefix`. Returned
-     * as a number (0 or 1 today, would grow if `concatFilesAtPrefix` is ever parallelized).
+     * Sum of list-objects requests currently in flight across all active `concatFilesAtPrefix`
+     * calls. Effectively 0 or 1 while `concatFilesAtPrefixProcessLimit === 1`; can grow up to
+     * that limit once cross-leaf parallelism is enabled.
      */
     get concatListObjectsInProgress(): number {
         return this._s3PrefixListObjectsProcessCount
+    }
+
+    /** Leaf `concatFilesAtPrefix` calls currently in flight (phase-2 workers). */
+    get concatFilesInProgress(): number {
+        return this._concatFilesAtPrefixProcessCount
     }
 
     get totalPrefixesToProcess(): number {
@@ -297,6 +357,7 @@ export class S3FileScanCat {
     getStats(): Readonly<S3FileScanCatStats> {
         return Object.freeze({
             partitionScansInProgress: this._scanPrefixForPartitionsProcessCount,
+            concatFilesInProgress: this._concatFilesAtPrefixProcessCount,
             concatListObjectsInProgress: this._s3PrefixListObjectsProcessCount,
             totalPrefixesToProcess: this._totalPrefixesToProcess,
             prefixesProcessedTotal: this._prefixesProcessedTotal,
@@ -449,24 +510,64 @@ export class S3FileScanCat {
             throw this._fatalScanError
         }
         this._totalPrefixesToProcess = this._allPrefixesRemaining()
-        if (this._totalPrefixesToProcess > 0) {
-            while (this._allPrefixesRemaining() > 0) {
-                const prefix = this._takeAllPrefix()
-                if (prefix) {
-                    await this.concatFilesAtPrefix(bucket, prefix, srcPrefix, destPath)
-                }
-            }
-        } else {
+        if (this._totalPrefixesToProcess <= 0) {
             throw new EmptyPrefixError()
         }
+        // Phase 2 fan-out. Mirrors phase 1 in intent but uses a Promise.race over the in-flight
+        // set instead of `waitUntil` polling — with `concatFilesAtPrefixProcessLimit === 1` and
+        // thousands of small leaves, a 10ms poll loop would add multi-second overhead for work
+        // that is otherwise essentially instant.
+        try {
+            while (
+                (this._allPrefixesRemaining() > 0 || this._inFlightConcatCalls.size > 0) &&
+                !this._fatalScanError
+            ) {
+                // Spawn as many leaves as the cap allows before blocking.
+                while (
+                    !this._fatalScanError &&
+                    this._allPrefixesRemaining() > 0 &&
+                    this._concatFilesAtPrefixProcessCount < this._concatFilesAtPrefixProcessLimit
+                ) {
+                    const prefix = this._takeAllPrefix()
+                    if (prefix === undefined) {
+                        break
+                    }
+                    this._concatFilesAtPrefixProcessCount++
+                    const concatPromise: Promise<void> = this.concatFilesAtPrefix(
+                        bucket,
+                        prefix,
+                        srcPrefix,
+                        destPath
+                    )
+                        .catch((err: unknown) => {
+                            void this._logger?.error(
+                                `Leaf concat failed for prefix=${prefix}: ${err instanceof Error ? err.message : String(err)}`
+                            )
+                            this._setFatalScanError(err)
+                        })
+                        .finally(() => {
+                            this._concatFilesAtPrefixProcessCount--
+                            this._inFlightConcatCalls.delete(concatPromise)
+                        })
+                    this._inFlightConcatCalls.add(concatPromise)
+                }
+                // Wait for at least one leaf to finish before considering the next batch. Each
+                // promise is `.catch`-wrapped above, so Promise.race never rejects here.
+                if (this._inFlightConcatCalls.size > 0) {
+                    await Promise.race([...this._inFlightConcatCalls])
+                }
+            }
+        } finally {
+            // Drain in-flight leaves regardless of outcome so callers never see
+            // `scanAndProcessFiles` resolve/reject while background concat is still running.
+            if (this._inFlightConcatCalls.size > 0) {
+                await Promise.allSettled([...this._inFlightConcatCalls])
+            }
+        }
+        if (this._fatalScanError) {
+            throw this._fatalScanError
+        }
 
-        // The sequential `await this.concatFilesAtPrefix(...)` loop above guarantees every
-        // leaf has finished concat (`_prefixesProcessedTotal`), and `_prefixesWithEmittedOutputTotal`
-        // has been updated for leaves that wrote at least one part, before we arrive here, so
-        // there is nothing left to wait for. A previous `waitUntil(... === ...)` at this
-        // spot was dead code *and* ignored `_fatalScanError`, which would have been a real
-        // hazard if the loop was ever parallelized. Removing it rather than "fixing" it
-        // because the explicit sequential await is already the correct invariant.
         void this._logger?.info(`Finished concatenating and compressing JSON S3 Objects for prefix=${srcPrefix}`)
         await this._logger?.flush()
         this._isDone = true
@@ -562,26 +663,16 @@ export class S3FileScanCat {
                                     `Skipping GetObject: listing Size (${s3Object.Size}) exceeds maxSourceObjectSizeBytes (${this._maxSourceObjectSizeBytes}) for key=${s3Object.Key}; preserving ordering with an empty slot.`
                                 )
                                 await waitUntil(
-                                    () => {
-                                        if (this._fatalScanError) {
-                                            return true
-                                        }
-                                        if (
-                                            concatState.bodiesInFlight <
-                                            this._s3ObjectBodyProcessInProgressLimit
-                                        ) {
-                                            return true
-                                        } else if (waits++ % 20 === 0) {
-                                            void this._logger?.trace(
-                                                `Waiting until GetObject body workers drop below limit (leafPrefix=${prefix}, inFlight=${concatState.bodiesInFlight}, limit=${this._s3ObjectBodyProcessInProgressLimit})`
-                                            )
-                                        }
-                                    },
+                                    () =>
+                                        this._tryAcquireBodySlot(concatState, prefix, () => waits++),
                                     { timeout: this._waitUntilTimeoutMs }
                                 )
                                 if (this._fatalScanError) {
                                     break
                                 }
+                                // The slot was reserved synchronously inside the acquire
+                                // predicate so a sibling leaf cannot observe the gate as open
+                                // before we have bumped the counters.
                                 const seq = nextSeq++
                                 const objectKey = s3Object.Key
                                 const skipPromise: Promise<void> = this._skipListedObjectOversizedForConcat(
@@ -606,25 +697,7 @@ export class S3FileScanCat {
                                 continue
                             }
                             await waitUntil(
-                                () => {
-                                    if (this._fatalScanError) {
-                                        return true
-                                    }
-                                    // Per-call backpressure: only this invocation's body workers
-                                    // count against the limit, so parallel concatFilesAtPrefix
-                                    // calls (if ever introduced) get their own concurrency budget
-                                    // instead of starving each other through a shared counter.
-                                    if (
-                                        concatState.bodiesInFlight <
-                                        this._s3ObjectBodyProcessInProgressLimit
-                                    ) {
-                                        return true
-                                    } else if (waits++ % 20 === 0) {
-                                        void this._logger?.trace(
-                                            `Waiting until GetObject body workers drop below limit (leafPrefix=${prefix}, inFlight=${concatState.bodiesInFlight}, limit=${this._s3ObjectBodyProcessInProgressLimit})`
-                                        )
-                                    }
-                                },
+                                () => this._tryAcquireBodySlot(concatState, prefix, () => waits++),
                                 { timeout: this._waitUntilTimeoutMs }
                             )
                             if (this._fatalScanError) {
@@ -789,8 +862,8 @@ export class S3FileScanCat {
         seq: number,
         s3Key: string
     ): Promise<void> {
-        concatState.bodiesInFlight++
-        this._s3ObjectBodyProcessInProgress++
+        // Counters were reserved synchronously by `_tryAcquireBodySlot` before spawn;
+        // we only need to release them here.
         try {
             if (this._fatalScanError) {
                 return
@@ -820,11 +893,11 @@ export class S3FileScanCat {
         destPrefix: string,
         seq: number
     ): Promise<void> {
-        // Per-call counter is authoritative for backpressure inside this concatFilesAtPrefix
-        // invocation. The class-level counter is retained as an aggregate rollup for the
+        // Counters were reserved synchronously by `_tryAcquireBodySlot` before this spawn, so
+        // the gate + bump happen in a single sync step (no microtask race across parallel
+        // leaves). We only release here. The per-call counter remains authoritative for
+        // in-leaf ordering; the class-level one is retained as an aggregate rollup for the
         // public `s3ObjectBodyProcessInProgress` getter.
-        concatState.bodiesInFlight++
-        this._s3ObjectBodyProcessInProgress++
         void this._logger?.trace(
             `BEGIN _getObjectBody objectKey=${s3Key} - _s3ObjectBodyProcessCount: ${this._s3ObjectBodyProcessInProgress}`
         )
@@ -970,6 +1043,8 @@ export class S3FileScanCat {
         this._isDone = false
         this._fatalScanError = undefined
         this._inFlightPartitionScans = new Set()
+        this._concatFilesAtPrefixProcessCount = 0
+        this._inFlightConcatCalls = new Set()
     }
 
     /** Number of items still to be taken from the `_keyParams` queue. */
@@ -1005,6 +1080,40 @@ export class S3FileScanCat {
         ;(this._allPrefixes as (string | undefined)[])[this._allPrefixesHead] = undefined
         this._allPrefixesHead++
         return item
+    }
+
+    /**
+     * Atomic check-and-increment used as the `waitUntil` predicate for body-worker slots.
+     * Runs synchronously, so the gate evaluation and the counter bump are inseparable — even
+     * with multiple `concatFilesAtPrefix` calls racing, no two can both observe the gate as
+     * open without the second seeing the first's increment. Returns true on fatal error so the
+     * caller can abort (no counters are bumped on the fatal path).
+     *
+     * Releasing is done by `_getAndProcessObjectBody` / `_skipListedObjectOversizedForConcat`
+     * in their `finally` blocks.
+     */
+    private _tryAcquireBodySlot(
+        concatState: ConcatState,
+        prefix: string,
+        bumpWaits: () => number
+    ): boolean {
+        if (this._fatalScanError) {
+            return true
+        }
+        if (
+            concatState.bodiesInFlight < this._s3ObjectBodyProcessInProgressLimit &&
+            this._s3ObjectBodyProcessInProgress < this._s3ObjectBodyProcessTotalLimit
+        ) {
+            concatState.bodiesInFlight++
+            this._s3ObjectBodyProcessInProgress++
+            return true
+        }
+        if (bumpWaits() % 20 === 0) {
+            void this._logger?.trace(
+                `Waiting until GetObject body workers drop below limits (leafPrefix=${prefix}, leafInFlight=${concatState.bodiesInFlight}/${this._s3ObjectBodyProcessInProgressLimit}, totalInFlight=${this._s3ObjectBodyProcessInProgress}/${this._s3ObjectBodyProcessTotalLimit})`
+            )
+        }
+        return false
     }
 
     /** Serialize buffer reads/writes/flushes across concurrent `_getAndProcessObjectBody` calls. */
@@ -1191,9 +1300,46 @@ export class S3FileScanCat {
     async _saveToS3(bucket: string, buffer: string, key: string): Promise<void> {
         void this._logger?.trace(`BEGIN _saveToS3 key=${key} - _s3ObjectPutProcessCount: ${this._s3ObjectPutProcessCount}`)
 
-        // Wrap the entire "in-flight" lifecycle in try/finally so `_s3ObjectPutProcessCount`
-        // cannot leak if gzip throws or PutObject rejects.
-        this._s3ObjectPutProcessCount++
+        // Class-level PutObject cap. The `tryAcquire` predicate performs the check-and-bump
+        // atomically (synchronously) so racing flush promises cannot both observe the gate as
+        // open. With the default `Infinity` the predicate always acquires on the first call and
+        // this is a no-op. When fatal, we short-circuit without bumping.
+        let putSlotAcquired = false
+        if (Number.isFinite(this._s3ObjectPutProcessLimit)) {
+            let putWaits = 0
+            await waitUntil(
+                () => {
+                    if (this._fatalScanError) {
+                        return true
+                    }
+                    if (this._s3ObjectPutProcessCount < this._s3ObjectPutProcessLimit) {
+                        this._s3ObjectPutProcessCount++
+                        putSlotAcquired = true
+                        return true
+                    }
+                    if (putWaits++ % 20 === 0) {
+                        void this._logger?.trace(
+                            `Waiting until PutObject workers drop below limit (inFlight=${this._s3ObjectPutProcessCount}, limit=${this._s3ObjectPutProcessLimit})`
+                        )
+                    }
+                    return false
+                },
+                { timeout: this._waitUntilTimeoutMs }
+            )
+            if (this._fatalScanError && !putSlotAcquired) {
+                // Honor the same abort semantics as other workers: skip the PUT and let the
+                // outer flush tracker's allSettled drain it. No counters to revert.
+                void this._logger?.trace(
+                    `Abandoning _saveToS3 key=${key} due to prior fatal scan error.`
+                )
+                return
+            }
+        } else {
+            // Unbounded: bump eagerly so both branches share the release path below.
+            this._s3ObjectPutProcessCount++
+            putSlotAcquired = true
+        }
+
         try {
             const body = await gzipAsync(buffer)
             const object: PutObjectCommandInput = {
@@ -1211,7 +1357,9 @@ export class S3FileScanCat {
             // counter is always decremented below.
             this._s3ObjectsPutTotal++
         } finally {
-            this._s3ObjectPutProcessCount--
+            if (putSlotAcquired) {
+                this._s3ObjectPutProcessCount--
+            }
             void this._logger?.trace(
                 `END _saveToS3 key=${key} - _s3ObjectPutProcessCount: ${this._s3ObjectPutProcessCount} - _s3ObjectsPutTotal: ${this._s3ObjectsPutTotal}`
             )

--- a/src/interfaces/scanner.interface.ts
+++ b/src/interfaces/scanner.interface.ts
@@ -57,9 +57,11 @@ export interface ScannerLimits {
      * `maxFileSizeBytes`) plus a `pendingBodies` map of unreleased source bodies. Peak
      * concat-buffer memory grows as `concatFilesAtPrefixProcessLimit × maxFileSizeBytes`.
      *
-     * Socket trade-off: combined with `s3ObjectBodyProcessTotalLimit` and
-     * `s3ObjectPutProcessLimit`, keep the sum comfortably below the S3 client's `maxSockets`
-     * (500) so list/get/put don't starve each other.
+     * Socket trade-off: concurrent `ListObjectsV2` in phase 1 is capped by
+     * `scanPrefixForPartitionsProcessLimit`; phase 2 can run one listing stream per in-flight leaf
+     * (`concatFilesAtPrefixProcessLimit`). Together with `s3ObjectBodyProcessTotalLimit` and
+     * `s3ObjectPutProcessLimit`, keep aggregate S3 concurrency comfortably below the client's
+     * `maxSockets` (500) so list/get/put don't starve each other.
      */
     concatFilesAtPrefixProcessLimit?: number
     /**

--- a/src/interfaces/scanner.interface.ts
+++ b/src/interfaces/scanner.interface.ts
@@ -47,6 +47,39 @@ export interface ScannerLimits {
      * which was easy to trip on legitimate traffic.
      */
     requestSocketTimeoutMs?: number
+    /**
+     * Max number of leaf `concatFilesAtPrefix` calls in flight concurrently during phase 2.
+     * Must be >= 1. Default **1** (original behavior: leaves are processed strictly one at a
+     * time). Raising this fans out cross-leaf work so a run with many small leaves isn't
+     * bottlenecked by a partially-utilized per-leaf body budget.
+     *
+     * Memory trade-off: each in-flight leaf holds its own concat buffer (bounded by
+     * `maxFileSizeBytes`) plus a `pendingBodies` map of unreleased source bodies. Peak
+     * concat-buffer memory grows as `concatFilesAtPrefixProcessLimit × maxFileSizeBytes`.
+     *
+     * Socket trade-off: combined with `s3ObjectBodyProcessTotalLimit` and
+     * `s3ObjectPutProcessLimit`, keep the sum comfortably below the S3 client's `maxSockets`
+     * (500) so list/get/put don't starve each other.
+     */
+    concatFilesAtPrefixProcessLimit?: number
+    /**
+     * Class-level cap on the total number of `_getAndProcessObjectBody` workers in flight
+     * across all leaves (aggregate of every leaf's `ConcatState.bodiesInFlight` plus
+     * oversized-skip bookkeeping). Must be >= `s3ObjectBodyProcessInProgressLimit` when
+     * supplied, to avoid starving a single leaf (the inner gate checks both caps).
+     *
+     * Default **Infinity** (opt-in). When `concatFilesAtPrefixProcessLimit > 1`, set this to
+     * bound socket usage and peak `pendingBodies` memory across concurrent leaves.
+     */
+    s3ObjectBodyProcessTotalLimit?: number
+    /**
+     * Class-level cap on the total number of `PutObject` calls in flight at any moment. Must be
+     * >= 1. Default **Infinity** (unchanged behavior). Intended to keep parallel leaves from
+     * monopolizing the socket pool during flushes; gating is applied at the start of
+     * `_saveToS3` before the in-flight counter is incremented, so published counters stay
+     * accurate.
+     */
+    s3ObjectPutProcessLimit?: number
 }
 
 export interface AWSConfig {
@@ -133,9 +166,15 @@ export interface S3FileScanCatStats {
     /** Partition-scan workers (`_scanPrefixForPartitions`) currently in flight during phase 1. */
     partitionScansInProgress: number
     /**
-     * Whether a list-objects request is currently in flight inside `concatFilesAtPrefix`.
-     * Because concatFilesAtPrefix currently runs one leaf at a time this is effectively 0 or 1;
-     * the field is a number so that a future parallelization does not change its shape.
+     * `concatFilesAtPrefix` calls currently in flight during phase 2. Bounded by
+     * `concatFilesAtPrefixProcessLimit` (default 1 = strictly sequential; raise for cross-leaf
+     * parallelism).
+     */
+    concatFilesInProgress: number
+    /**
+     * Sum of list-objects requests currently in flight across all active `concatFilesAtPrefix`
+     * calls. Effectively 0 or 1 when `concatFilesAtPrefixProcessLimit === 1`; can grow up to
+     * `concatFilesAtPrefixProcessLimit` when multiple leaves run in parallel.
      */
     concatListObjectsInProgress: number
     /** Leaf prefixes enqueued for the concat phase when the current run entered phase 2. */

--- a/test/S3FileScanCat.edges.test.ts
+++ b/test/S3FileScanCat.edges.test.ts
@@ -1572,4 +1572,349 @@ describe('S3FileScanCat edges (mocked S3)', () => {
         await first
         expect(cat.isDone).toBe(true)
     })
+
+    it('defaults to serial leaf concat (concatFilesAtPrefixProcessLimit = 1)', async () => {
+        // Back-compat guard: with the new limit unset, only one concatFilesAtPrefix call is in
+        // flight at a time. Verify by watching `concatFilesInProgress` (new stat) while leaves
+        // list.
+        const leaves = Array.from({ length: 4 }, (_, i) => `data/src/year=${2020 + i}/`)
+        s3Mock.on(ListObjectsV2Command).callsFake((input) => {
+            if (input.Delimiter === '/') {
+                return Promise.resolve({
+                    CommonPrefixes: leaves.map((p) => ({ Prefix: p })),
+                    IsTruncated: false,
+                })
+            }
+            return Promise.resolve({
+                Contents: [{ Key: `${input.Prefix}one.json`, Size: 8 }],
+                IsTruncated: false,
+            })
+        })
+        s3Mock.on(GetObjectCommand).callsFake(() =>
+            Promise.resolve({ Body: sdkStreamMixin(Readable.from(['{"k":1}'])) })
+        )
+        s3Mock.on(PutObjectCommand).resolves({})
+
+        const cat = new S3FileScanCat(false, scannerOptions({ partitionStack: ['year'] }), testAwsSecrets)
+
+        // Sample `concatFilesInProgress` periodically while the scan runs.
+        let peakConcat = 0
+        const sampler = setInterval(() => {
+            peakConcat = Math.max(peakConcat, cat.getStats().concatFilesInProgress)
+        }, 1)
+        try {
+            await cat.scanAndProcessFiles('bucket', 'data/src', 'data/dst')
+        } finally {
+            clearInterval(sampler)
+        }
+        expect(peakConcat).toBeLessThanOrEqual(1)
+        expect(cat.prefixesProcessedTotal).toBe(leaves.length)
+    })
+
+    it('runs multiple leaves in parallel when concatFilesAtPrefixProcessLimit > 1', async () => {
+        // Two leaves each hold their GetObject open until we release. If leaves really run in
+        // parallel we should see two list-objects calls AND two pending GetObjects before
+        // releasing either.
+        const leaves = ['data/src/year=2020/', 'data/src/year=2021/']
+        s3Mock.on(ListObjectsV2Command).callsFake((input) => {
+            if (input.Delimiter === '/') {
+                return Promise.resolve({
+                    CommonPrefixes: leaves.map((p) => ({ Prefix: p })),
+                    IsTruncated: false,
+                })
+            }
+            return Promise.resolve({
+                Contents: [{ Key: `${input.Prefix}a.json`, Size: 8 }],
+                IsTruncated: false,
+            })
+        })
+
+        const pendingResolvers: Array<(v: unknown) => void> = []
+        s3Mock.on(GetObjectCommand).callsFake(
+            () =>
+                new Promise((resolve) => {
+                    pendingResolvers.push(resolve as (v: unknown) => void)
+                })
+        )
+        s3Mock.on(PutObjectCommand).resolves({})
+
+        const cat = new S3FileScanCat(
+            false,
+            scannerOptions({
+                partitionStack: ['year'],
+                limits: { concatFilesAtPrefixProcessLimit: 2 },
+            }),
+            testAwsSecrets
+        )
+        const run = cat.scanAndProcessFiles('bucket', 'data/src', 'data/dst')
+
+        for (let i = 0; i < 50 && pendingResolvers.length < 2; i++) {
+            await new Promise((r) => setTimeout(r, 5))
+        }
+        expect(pendingResolvers.length).toBe(2)
+        // Both leaves must be in flight concurrently for both GetObjects to register.
+        expect(cat.getStats().concatFilesInProgress).toBe(2)
+
+        pendingResolvers[0]({ Body: sdkStreamMixin(Readable.from(['{"x":1}'])) })
+        pendingResolvers[1]({ Body: sdkStreamMixin(Readable.from(['{"y":2}'])) })
+        await run
+
+        expect(cat.isDone).toBe(true)
+        const putKeys = s3Mock.commandCalls(PutObjectCommand).map((c) => c.args[0].input.Key).sort()
+        expect(putKeys).toEqual(['data/dst/year=2020/0.json.gz', 'data/dst/year=2021/0.json.gz'])
+    })
+
+    it('enforces s3ObjectBodyProcessTotalLimit across parallel leaves', async () => {
+        // Three leaves, each with two keys, and a class-level cap of 3. Without the cap the peak
+        // in-flight would be 3 leaves * 2 keys = 6; with the cap we must never exceed 3.
+        const leaves = ['data/src/year=2020/', 'data/src/year=2021/', 'data/src/year=2022/']
+        s3Mock.on(ListObjectsV2Command).callsFake((input) => {
+            if (input.Delimiter === '/') {
+                return Promise.resolve({
+                    CommonPrefixes: leaves.map((p) => ({ Prefix: p })),
+                    IsTruncated: false,
+                })
+            }
+            return Promise.resolve({
+                Contents: [
+                    { Key: `${input.Prefix}a.json`, Size: 8 },
+                    { Key: `${input.Prefix}b.json`, Size: 8 },
+                ],
+                IsTruncated: false,
+            })
+        })
+
+        const pendingResolvers: Array<(v: unknown) => void> = []
+        s3Mock.on(GetObjectCommand).callsFake(
+            () =>
+                new Promise((resolve) => {
+                    pendingResolvers.push(resolve as (v: unknown) => void)
+                })
+        )
+        s3Mock.on(PutObjectCommand).resolves({})
+
+        const cat = new S3FileScanCat(
+            false,
+            scannerOptions({
+                partitionStack: ['year'],
+                limits: {
+                    concatFilesAtPrefixProcessLimit: 3,
+                    s3ObjectBodyProcessInProgressLimit: 2,
+                    s3ObjectBodyProcessTotalLimit: 3,
+                },
+            }),
+            testAwsSecrets
+        )
+        const run = cat.scanAndProcessFiles('bucket', 'data/src', 'data/dst')
+
+        // Give the scan time to saturate to the cap.
+        let peakBodies = 0
+        for (let i = 0; i < 30; i++) {
+            await new Promise((r) => setTimeout(r, 5))
+            peakBodies = Math.max(peakBodies, cat.getStats().s3ObjectBodyWorkersInProgress)
+        }
+        expect(peakBodies).toBe(3)
+        // More than 3 would mean the cap was violated; fewer would be a starvation bug.
+        expect(pendingResolvers.length).toBe(3)
+
+        // Drain. As each in-flight body resolves, another should slot in until all 6 are done.
+        for (let i = 0; i < 6; i++) {
+            while (pendingResolvers.length <= i) {
+                await new Promise((r) => setTimeout(r, 5))
+            }
+            // Assert the in-flight total never exceeded the cap while draining either.
+            expect(cat.getStats().s3ObjectBodyWorkersInProgress).toBeLessThanOrEqual(3)
+            pendingResolvers[i]({ Body: sdkStreamMixin(Readable.from(['{"k":1}'])) })
+        }
+        await run
+        expect(cat.prefixesProcessedTotal).toBe(3)
+    })
+
+    it('enforces s3ObjectPutProcessLimit across parallel leaves', async () => {
+        // Three leaves in parallel, each writes one output part. Cap PutObject at 1 and verify
+        // it is never exceeded.
+        const leaves = ['data/src/year=2020/', 'data/src/year=2021/', 'data/src/year=2022/']
+        s3Mock.on(ListObjectsV2Command).callsFake((input) => {
+            if (input.Delimiter === '/') {
+                return Promise.resolve({
+                    CommonPrefixes: leaves.map((p) => ({ Prefix: p })),
+                    IsTruncated: false,
+                })
+            }
+            return Promise.resolve({
+                Contents: [{ Key: `${input.Prefix}a.json`, Size: 8 }],
+                IsTruncated: false,
+            })
+        })
+        s3Mock.on(GetObjectCommand).callsFake(() =>
+            Promise.resolve({ Body: sdkStreamMixin(Readable.from(['{"k":1}'])) })
+        )
+
+        // Hold each PutObject for a tick so the scanner has to queue them.
+        const putResolvers: Array<() => void> = []
+        s3Mock.on(PutObjectCommand).callsFake(
+            () =>
+                new Promise<object>((resolve) => {
+                    putResolvers.push(() => resolve({}))
+                })
+        )
+
+        const cat = new S3FileScanCat(
+            false,
+            scannerOptions({
+                partitionStack: ['year'],
+                limits: {
+                    concatFilesAtPrefixProcessLimit: 3,
+                    s3ObjectPutProcessLimit: 1,
+                },
+            }),
+            testAwsSecrets
+        )
+        const run = cat.scanAndProcessFiles('bucket', 'data/src', 'data/dst')
+
+        // Exactly one PutObject should be in flight at a time; wait for the first to register.
+        for (let i = 0; i < 50 && putResolvers.length < 1; i++) {
+            await new Promise((r) => setTimeout(r, 5))
+        }
+        expect(putResolvers.length).toBe(1)
+        expect(cat.getStats().s3ObjectPutWorkersInProgress).toBe(1)
+
+        // Release in order, each time waiting for the next PUT to be dispatched.
+        for (let i = 0; i < 3; i++) {
+            expect(cat.getStats().s3ObjectPutWorkersInProgress).toBeLessThanOrEqual(1)
+            putResolvers[i]()
+            if (i < 2) {
+                for (let j = 0; j < 50 && putResolvers.length <= i + 1; j++) {
+                    await new Promise((r) => setTimeout(r, 5))
+                }
+            }
+        }
+        await run
+        expect(cat.s3ObjectsPutTotal).toBe(3)
+    })
+
+    it('drains parallel leaves and rethrows the original error when one leaf fails', async () => {
+        // Leaf A rejects during GetObject; leaf B blocks on GetObject. Confirm scanAndProcessFiles
+        // rejects with A's error, B is drained before the outer rejection resolves, and no stray
+        // Put lands after the rejection.
+        const leaves = ['data/src/year=2020/', 'data/src/year=2021/']
+        s3Mock.on(ListObjectsV2Command).callsFake((input) => {
+            if (input.Delimiter === '/') {
+                return Promise.resolve({
+                    CommonPrefixes: leaves.map((p) => ({ Prefix: p })),
+                    IsTruncated: false,
+                })
+            }
+            return Promise.resolve({
+                Contents: [{ Key: `${input.Prefix}a.json`, Size: 8 }],
+                IsTruncated: false,
+            })
+        })
+
+        let releaseB: (() => void) | undefined
+        s3Mock.on(GetObjectCommand).callsFake((input) => {
+            if (input.Key === 'data/src/year=2020/a.json') {
+                return Promise.reject(Object.assign(new Error('boom-A'), { name: 'AccessDenied' }))
+            }
+            return new Promise((resolve) => {
+                releaseB = () => resolve({ Body: sdkStreamMixin(Readable.from(['{"y":2}'])) })
+            })
+        })
+        s3Mock.on(PutObjectCommand).resolves({})
+
+        const cat = new S3FileScanCat(
+            false,
+            scannerOptions({
+                partitionStack: ['year'],
+                limits: { concatFilesAtPrefixProcessLimit: 2, waitUntilTimeoutMs: 5_000 },
+            }),
+            testAwsSecrets
+        )
+        const run = cat.scanAndProcessFiles('bucket', 'data/src', 'data/dst')
+
+        // Wait for leaf B to register its pending GetObject.
+        for (let i = 0; i < 50 && releaseB === undefined; i++) {
+            await new Promise((r) => setTimeout(r, 5))
+        }
+        expect(typeof releaseB).toBe('function')
+
+        // Let leaf B complete after leaf A has failed; the drain must pick it up.
+        releaseB?.()
+        await expect(run).rejects.toThrow('boom-A')
+
+        // No rogue work left running after rejection.
+        expect(cat.getStats().concatFilesInProgress).toBe(0)
+        expect(cat.getStats().s3ObjectBodyWorkersInProgress).toBe(0)
+        expect(cat.getStats().s3ObjectPutWorkersInProgress).toBe(0)
+    })
+
+    it('_resetRunState() clears phase-2 concurrency state for subsequent runs', async () => {
+        stubPartitionAndConcatList(() => ({
+            Contents: [{ Key: 'data/src/year=2020/a.json', Size: 8 }],
+            IsTruncated: false,
+        }))
+        s3Mock.on(GetObjectCommand).callsFake(() =>
+            Promise.resolve({ Body: sdkStreamMixin(Readable.from(['{"x":1}'])) })
+        )
+        s3Mock.on(PutObjectCommand).resolves({})
+
+        const cat = new S3FileScanCat(
+            false,
+            scannerOptions({
+                partitionStack: ['year'],
+                limits: { concatFilesAtPrefixProcessLimit: 2 },
+            }),
+            testAwsSecrets
+        )
+        await cat.scanAndProcessFiles('bucket', 'data/src', 'data/dst')
+        expect(cat.isDone).toBe(true)
+        expect(cat.getStats().concatFilesInProgress).toBe(0)
+
+        // Second run on the same instance must not observe leftover counters.
+        await cat.scanAndProcessFiles('bucket', 'data/src', 'data/dst')
+        expect(cat.isDone).toBe(true)
+        expect(cat.getStats().concatFilesInProgress).toBe(0)
+        expect(cat.prefixesProcessedTotal).toBe(1)
+    })
+
+    it('rejects invalid concurrency limits at construction', () => {
+        expect(
+            () =>
+                new S3FileScanCat(
+                    false,
+                    scannerOptions({
+                        partitionStack: ['year'],
+                        limits: { concatFilesAtPrefixProcessLimit: 0 },
+                    }),
+                    testAwsSecrets
+                )
+        ).toThrow(/concatFilesAtPrefixProcessLimit/)
+
+        expect(
+            () =>
+                new S3FileScanCat(
+                    false,
+                    scannerOptions({
+                        partitionStack: ['year'],
+                        limits: {
+                            s3ObjectBodyProcessInProgressLimit: 10,
+                            s3ObjectBodyProcessTotalLimit: 5,
+                        },
+                    }),
+                    testAwsSecrets
+                )
+        ).toThrow(/s3ObjectBodyProcessTotalLimit/)
+
+        expect(
+            () =>
+                new S3FileScanCat(
+                    false,
+                    scannerOptions({
+                        partitionStack: ['year'],
+                        limits: { s3ObjectPutProcessLimit: 0 },
+                    }),
+                    testAwsSecrets
+                )
+        ).toThrow(/s3ObjectPutProcessLimit/)
+    })
 })

--- a/test/S3FileScanCat.edges.test.ts
+++ b/test/S3FileScanCat.edges.test.ts
@@ -1574,10 +1574,12 @@ describe('S3FileScanCat edges (mocked S3)', () => {
     })
 
     it('defaults to serial leaf concat (concatFilesAtPrefixProcessLimit = 1)', async () => {
-        // Back-compat guard: with the new limit unset, only one concatFilesAtPrefix call is in
-        // flight at a time. Verify by watching `concatFilesInProgress` (new stat) while leaves
-        // list.
-        const leaves = Array.from({ length: 4 }, (_, i) => `data/src/year=${2020 + i}/`)
+        // Back-compat guard: with the new limit unset, the second leaf MUST NOT begin until the
+        // first has finished. We prove this deterministically by holding the first leaf's
+        // GetObject unresolved and asserting no second concat call has started. Sampling a
+        // counter on a timer can miss brief spikes; pinning the first worker makes the absence
+        // of the second observable.
+        const leaves = ['data/src/year=2020/', 'data/src/year=2021/', 'data/src/year=2022/']
         s3Mock.on(ListObjectsV2Command).callsFake((input) => {
             if (input.Delimiter === '/') {
                 return Promise.resolve({
@@ -1590,25 +1592,57 @@ describe('S3FileScanCat edges (mocked S3)', () => {
                 IsTruncated: false,
             })
         })
-        s3Mock.on(GetObjectCommand).callsFake(() =>
-            Promise.resolve({ Body: sdkStreamMixin(Readable.from(['{"k":1}'])) })
+
+        // Key → resolver for that key's GetObject.
+        const resolvers = new Map<string, (v: unknown) => void>()
+        s3Mock.on(GetObjectCommand).callsFake(
+            (input) =>
+                new Promise((resolve) => {
+                    resolvers.set(input.Key ?? '', resolve as (v: unknown) => void)
+                })
         )
         s3Mock.on(PutObjectCommand).resolves({})
 
         const cat = new S3FileScanCat(false, scannerOptions({ partitionStack: ['year'] }), testAwsSecrets)
+        const run = cat.scanAndProcessFiles('bucket', 'data/src', 'data/dst')
 
-        // Sample `concatFilesInProgress` periodically while the scan runs.
-        let peakConcat = 0
-        const sampler = setInterval(() => {
-            peakConcat = Math.max(peakConcat, cat.getStats().concatFilesInProgress)
-        }, 1)
-        try {
-            await cat.scanAndProcessFiles('bucket', 'data/src', 'data/dst')
-        } finally {
-            clearInterval(sampler)
+        // Wait for the first leaf's GetObject to register. In serial mode, this is the only
+        // pending Get until we release it.
+        const firstKey = `${leaves[0]}one.json`
+        const secondKey = `${leaves[1]}one.json`
+        for (let i = 0; i < 50 && !resolvers.has(firstKey); i++) {
+            await new Promise((r) => setTimeout(r, 5))
         }
-        expect(peakConcat).toBeLessThanOrEqual(1)
+        expect(resolvers.has(firstKey)).toBe(true)
+        // Give the event loop plenty of chances to incorrectly start leaf 2. If parallelism
+        // regresses, leaf 2's list + GetObject would register during these ticks.
+        for (let i = 0; i < 20; i++) {
+            await new Promise((r) => setTimeout(r, 5))
+        }
+        expect(resolvers.size).toBe(1)
+        expect(resolvers.has(secondKey)).toBe(false)
+        expect(cat.getStats().concatFilesInProgress).toBe(1)
+
+        // Release each leaf in sequence. After leaf N completes, leaf N+1 should be the next
+        // and only leaf to register a GetObject.
+        for (let i = 0; i < leaves.length; i++) {
+            const key = `${leaves[i]}one.json`
+            expect(resolvers.has(key)).toBe(true)
+            resolvers.get(key)!({ Body: sdkStreamMixin(Readable.from(['{"k":1}'])) })
+            if (i + 1 < leaves.length) {
+                const nextKey = `${leaves[i + 1]}one.json`
+                for (let j = 0; j < 50 && !resolvers.has(nextKey); j++) {
+                    await new Promise((r) => setTimeout(r, 5))
+                }
+                expect(resolvers.has(nextKey)).toBe(true)
+                // At no point should two leaves be concurrently in flight in serial mode.
+                expect(cat.getStats().concatFilesInProgress).toBe(1)
+            }
+        }
+
+        await run
         expect(cat.prefixesProcessedTotal).toBe(leaves.length)
+        expect(cat.getStats().concatFilesInProgress).toBe(0)
     })
 
     it('runs multiple leaves in parallel when concatFilesAtPrefixProcessLimit > 1', async () => {
@@ -1846,6 +1880,32 @@ describe('S3FileScanCat edges (mocked S3)', () => {
         expect(cat.getStats().concatFilesInProgress).toBe(0)
         expect(cat.getStats().s3ObjectBodyWorkersInProgress).toBe(0)
         expect(cat.getStats().s3ObjectPutWorkersInProgress).toBe(0)
+    })
+
+    it('_saveToS3 abandons the PUT after a fatal error even with unbounded PutObject cap', async () => {
+        // Regression test: prior to the fix, the Infinity (default) branch of `_saveToS3`
+        // bumped the counter and proceeded to gzip + PutObject without checking fatal, so a
+        // detached flush could land a PUT after the scan had already rejected. Now we abandon
+        // consistently regardless of whether the PUT cap is finite or infinite.
+        s3Mock.on(PutObjectCommand).resolves({})
+
+        const cat = new S3FileScanCat(
+            false,
+            scannerOptions({ partitionStack: ['year'] }),
+            testAwsSecrets
+        )
+        // Default is Infinity — this exercises the formerly unchecked branch.
+        expect((cat as unknown as { _s3ObjectPutProcessLimit: number })._s3ObjectPutProcessLimit).toBe(
+            Number.POSITIVE_INFINITY
+        )
+
+        cat._setFatalScanError(new Error('prior failure'))
+        // Calling _saveToS3 directly is the clearest way to pin the branch.
+        await cat._saveToS3('bucket', 'ignored body', 'data/dst/should-not-exist.json.gz')
+
+        expect(s3Mock.commandCalls(PutObjectCommand).length).toBe(0)
+        expect(cat.s3ObjectsPutTotal).toBe(0)
+        expect(cat.s3ObjectPutProcessCount).toBe(0)
     })
 
     it('_resetRunState() clears phase-2 concurrency state for subsequent runs', async () => {

--- a/test/S3FileScanCat.edges.test.ts
+++ b/test/S3FileScanCat.edges.test.ts
@@ -1917,4 +1917,75 @@ describe('S3FileScanCat edges (mocked S3)', () => {
                 )
         ).toThrow(/s3ObjectPutProcessLimit/)
     })
+
+    it('rejects fractional concurrency limits at construction (cap could otherwise be exceeded)', () => {
+        // Every gate compares `count < limit` and then bumps by 1. A fractional limit like 1.5
+        // would let 2 workers through (1 < 1.5), which violates the cap. Require integers.
+        expect(
+            () =>
+                new S3FileScanCat(
+                    false,
+                    scannerOptions({
+                        partitionStack: ['year'],
+                        limits: { concatFilesAtPrefixProcessLimit: 1.5 },
+                    }),
+                    testAwsSecrets
+                )
+        ).toThrow(/concatFilesAtPrefixProcessLimit/)
+
+        expect(
+            () =>
+                new S3FileScanCat(
+                    false,
+                    scannerOptions({
+                        partitionStack: ['year'],
+                        limits: { concatFilesAtPrefixProcessLimit: Number.POSITIVE_INFINITY },
+                    }),
+                    testAwsSecrets
+                )
+        ).toThrow(/concatFilesAtPrefixProcessLimit/)
+
+        expect(
+            () =>
+                new S3FileScanCat(
+                    false,
+                    scannerOptions({
+                        partitionStack: ['year'],
+                        limits: {
+                            s3ObjectBodyProcessInProgressLimit: 2,
+                            s3ObjectBodyProcessTotalLimit: 2.5,
+                        },
+                    }),
+                    testAwsSecrets
+                )
+        ).toThrow(/s3ObjectBodyProcessTotalLimit/)
+
+        expect(
+            () =>
+                new S3FileScanCat(
+                    false,
+                    scannerOptions({
+                        partitionStack: ['year'],
+                        limits: { s3ObjectPutProcessLimit: 3.25 },
+                    }),
+                    testAwsSecrets
+                )
+        ).toThrow(/s3ObjectPutProcessLimit/)
+
+        // Infinity is allowed for the two caps that default to Infinity.
+        expect(
+            () =>
+                new S3FileScanCat(
+                    false,
+                    scannerOptions({
+                        partitionStack: ['year'],
+                        limits: {
+                            s3ObjectBodyProcessTotalLimit: Number.POSITIVE_INFINITY,
+                            s3ObjectPutProcessLimit: Number.POSITIVE_INFINITY,
+                        },
+                    }),
+                    testAwsSecrets
+                )
+        ).not.toThrow()
+    })
 })

--- a/test/S3FileScanCat.edges.test.ts
+++ b/test/S3FileScanCat.edges.test.ts
@@ -1988,4 +1988,86 @@ describe('S3FileScanCat edges (mocked S3)', () => {
                 )
         ).not.toThrow()
     })
+
+    it('rejects NaN and non-number concurrency limits (gates would never open otherwise)', () => {
+        // NaN would make every `count < NaN` comparison false, so the predicate never returns
+        // true and `waitUntil` spins until the timeout. Surface it at construction instead.
+        expect(
+            () =>
+                new S3FileScanCat(
+                    false,
+                    scannerOptions({
+                        partitionStack: ['year'],
+                        limits: { concatFilesAtPrefixProcessLimit: Number.NaN },
+                    }),
+                    testAwsSecrets
+                )
+        ).toThrow(/concatFilesAtPrefixProcessLimit/)
+
+        expect(
+            () =>
+                new S3FileScanCat(
+                    false,
+                    scannerOptions({
+                        partitionStack: ['year'],
+                        limits: { s3ObjectBodyProcessTotalLimit: Number.NaN },
+                    }),
+                    testAwsSecrets
+                )
+        ).toThrow(/s3ObjectBodyProcessTotalLimit/)
+
+        expect(
+            () =>
+                new S3FileScanCat(
+                    false,
+                    scannerOptions({
+                        partitionStack: ['year'],
+                        limits: { s3ObjectPutProcessLimit: Number.NaN },
+                    }),
+                    testAwsSecrets
+                )
+        ).toThrow(/s3ObjectPutProcessLimit/)
+
+        // Non-number runtime values (bypassing TS) must also be rejected.
+        expect(
+            () =>
+                new S3FileScanCat(
+                    false,
+                    scannerOptions({
+                        partitionStack: ['year'],
+                        limits: {
+                            s3ObjectPutProcessLimit: '10' as unknown as number,
+                        },
+                    }),
+                    testAwsSecrets
+                )
+        ).toThrow(/s3ObjectPutProcessLimit/)
+
+        expect(
+            () =>
+                new S3FileScanCat(
+                    false,
+                    scannerOptions({
+                        partitionStack: ['year'],
+                        limits: {
+                            concatFilesAtPrefixProcessLimit: null as unknown as number,
+                        },
+                    }),
+                    testAwsSecrets
+                )
+        ).toThrow(/concatFilesAtPrefixProcessLimit/)
+
+        // Negative Infinity is a number but not a legitimate limit.
+        expect(
+            () =>
+                new S3FileScanCat(
+                    false,
+                    scannerOptions({
+                        partitionStack: ['year'],
+                        limits: { s3ObjectPutProcessLimit: Number.NEGATIVE_INFINITY },
+                    }),
+                    testAwsSecrets
+                )
+        ).toThrow(/s3ObjectPutProcessLimit/)
+    })
 })


### PR DESCRIPTION
This pull request introduces configurable concurrency controls to the S3 file scanning and concatenation process, allowing for parallelization of phase-2 operations and more precise resource management. It adds new concurrency limit options, updates the implementation to support parallel leaf processing, and documents these features for users. These changes enable significant speedups for workloads with many small files while providing safeguards for memory and socket usage.

**Concurrency controls and parallelization:**

* Added new concurrency limit options to the configuration and constructor: `concatFilesAtPrefixProcessLimit` (parallel leaf processing), `s3ObjectBodyProcessTotalLimit` (total in-flight `GetObject` bodies), and `s3ObjectPutProcessLimit` (concurrent `PutObject` calls). Validation ensures safe and predictable behavior. [[1]](diffhunk://#diff-3fb943a47395d3c3c38f045643b61378e5d7801ebaa6e79fa231dd13c3bbc0afR77-R89) [[2]](diffhunk://#diff-3fb943a47395d3c3c38f045643b61378e5d7801ebaa6e79fa231dd13c3bbc0afR130-R168) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R66-R68)
* Refactored phase-2 (concatenate-and-write) logic to use a Promise-based fan-out model, supporting multiple concurrent `concatFilesAtPrefix` workers up to the configured limit. This replaces the previous strictly sequential execution.
* Implemented atomic gating for body-worker slot acquisition via the new `_tryAcquireBodySlot` method, ensuring correct concurrency even under parallel leaf execution. [[1]](diffhunk://#diff-3fb943a47395d3c3c38f045643b61378e5d7801ebaa6e79fa231dd13c3bbc0afR1085-R1118) [[2]](diffhunk://#diff-3fb943a47395d3c3c38f045643b61378e5d7801ebaa6e79fa231dd13c3bbc0afL565-R675) [[3]](diffhunk://#diff-3fb943a47395d3c3c38f045643b61378e5d7801ebaa6e79fa231dd13c3bbc0afL609-R700)
* Updated statistics and public getters to reflect new concurrency metrics, including `concatFilesInProgress`. [[1]](diffhunk://#diff-3fb943a47395d3c3c38f045643b61378e5d7801ebaa6e79fa231dd13c3bbc0afL231-R306) [[2]](diffhunk://#diff-3fb943a47395d3c3c38f045643b61378e5d7801ebaa6e79fa231dd13c3bbc0afR360)

**Documentation:**

* Expanded the `README.md` with a new "Tuning concurrency" section, describing the new configuration options, their defaults, and guidance on resource ceilings and safe upgrades.

These changes provide both improved performance and enhanced control for users processing large numbers of S3 files in parallel.- Introduced new configuration options in the ScannerLimits interface: `concatFilesAtPrefixProcessLimit`, `s3ObjectBodyProcessTotalLimit`, and `s3ObjectPutProcessLimit` to enhance parallel processing capabilities during the concatenation phase.
- Updated the S3FileScanCat class to implement these limits, allowing for greater control over concurrent operations and improving performance for scans with many small files.
- Enhanced documentation to clarify the purpose and usage of the new limits, including memory and socket considerations.
- Added tests to validate the behavior of the new concurrency settings, ensuring correct enforcement of limits during processing.